### PR TITLE
修复 Claude Code workflow 配置

### DIFF
--- a/.github/workflows/claudecode.yml
+++ b/.github/workflows/claudecode.yml
@@ -19,9 +19,9 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
-      issues: read
+      contents: write
+      pull-requests: write
+      issues: write
       id-token: write
     steps:
       - name: Checkout repository
@@ -41,3 +41,4 @@ jobs:
           ANTHROPIC_BASE_URL: "${{ secrets.ANTHROPIC_BASE_URL }}"
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
- 添加 github_token 参数以正确传递 GitHub token
- 将权限从 read 改为 write (contents, pull-requests, issues)
- 修复触发器无法识别 @claude 提及的问题